### PR TITLE
🐛 fix: capsule isOpened 수정

### DIFF
--- a/src/main/java/com/example/echo/domain/capsule/converter/CapsuleConverter.java
+++ b/src/main/java/com/example/echo/domain/capsule/converter/CapsuleConverter.java
@@ -67,7 +67,6 @@ public class CapsuleConverter {
     // Entity -> Preview DTO
     public static CapsuleResDTO.CapsulePreviewResDTO toCapsulePreviewDto(Capsule capsule, AuthUser authUser) {
         LocalDateTime now = LocalDateTime.now();
-        //boolean isOpened = capsule.isOpened() || now.isAfter(capsule.getDeadLine().atStartOfDay());
         return CapsuleResDTO.CapsulePreviewResDTO.builder()
                 .id(capsule.getId())
                 .userId(authUser.getId())
@@ -86,7 +85,6 @@ public class CapsuleConverter {
                 .map(Image::getImageUrl)
                 .collect(Collectors.toList());
         LocalDateTime now = LocalDateTime.now();
-       // boolean isOpened = capsule.isOpened() || now.isAfter(capsule.getDeadLine().atStartOfDay());
 
         return CapsuleResDTO.CapsuleDetailResDTO.builder()
                 .capsuleId(capsule.getId())

--- a/src/main/java/com/example/echo/domain/capsule/converter/CapsuleConverter.java
+++ b/src/main/java/com/example/echo/domain/capsule/converter/CapsuleConverter.java
@@ -67,12 +67,12 @@ public class CapsuleConverter {
     // Entity -> Preview DTO
     public static CapsuleResDTO.CapsulePreviewResDTO toCapsulePreviewDto(Capsule capsule, AuthUser authUser) {
         LocalDateTime now = LocalDateTime.now();
-        boolean isOpened = capsule.isOpened() || now.isAfter(capsule.getDeadLine().atStartOfDay());
+        //boolean isOpened = capsule.isOpened() || now.isAfter(capsule.getDeadLine().atStartOfDay());
         return CapsuleResDTO.CapsulePreviewResDTO.builder()
                 .id(capsule.getId())
                 .userId(authUser.getId())
                 .tagName(capsule.getTagName())
-                .isOpened(isOpened)
+                .isOpened(capsule.isOpened())
                 .title(capsule.getTitle())
                 .createdAt(capsule.getCreatedAt())
                 .now(now)
@@ -86,12 +86,12 @@ public class CapsuleConverter {
                 .map(Image::getImageUrl)
                 .collect(Collectors.toList());
         LocalDateTime now = LocalDateTime.now();
-        boolean isOpened = capsule.isOpened() || now.isAfter(capsule.getDeadLine().atStartOfDay());
+       // boolean isOpened = capsule.isOpened() || now.isAfter(capsule.getDeadLine().atStartOfDay());
 
         return CapsuleResDTO.CapsuleDetailResDTO.builder()
                 .capsuleId(capsule.getId())
                 .userId(authUser.getId())
-                .isOpened(isOpened)
+                .isOpened(capsule.isOpened())
                 .title(capsule.getTitle())
                 .content(capsule.getContent())
                 .imageList(imageUrls)

--- a/src/main/java/com/example/echo/domain/capsule/entity/Capsule.java
+++ b/src/main/java/com/example/echo/domain/capsule/entity/Capsule.java
@@ -66,4 +66,9 @@ public class Capsule extends BaseEntity {
     public void setImageList(List<Image> images) {
         this.images = images;
     }
+    public void setIsOpened(){
+        if(LocalDateTime.now().isAfter(deadLine.atStartOfDay())){
+            this.isOpened = true;
+        }
+    }
 }

--- a/src/main/java/com/example/echo/domain/capsule/service/query/CapsuleQueryService.java
+++ b/src/main/java/com/example/echo/domain/capsule/service/query/CapsuleQueryService.java
@@ -13,13 +13,15 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 @Service
-@Transactional(readOnly = true)
+@Transactional
 @RequiredArgsConstructor
 public class CapsuleQueryService {
     private final CapsuleRepository capsuleRepository;
 
     public List<CapsuleResDTO.CapsulePreviewResDTO> getCapsules(AuthUser authUser){
         List<Capsule> capsules = capsuleRepository.findByUserIdAndDeletedAtIsNull(authUser.getId());
+        capsules.forEach(capsule -> capsule.setIsOpened());
+        capsuleRepository.saveAll(capsules);
         return CapsuleConverter.fromList(capsules, authUser);
     }
 


### PR DESCRIPTION
# ☝️Issue Number

- # 이슈번호

##  📌 개요

- converter에서 boolean isOpened = capsule.isOpened() || now.isAfter(capsule.getDeadLine().atStartOfDay()); 실행하면 capsule의 isOpend가 false여도 deadline이 지난 상태면 dto에 isOpened가 true로 반환되는 오류 수정
- capsule 특정 사용자 프리뷰 조회 시 deadline 지난 capsule에 대해 isOpended를 true로 바꿔주도록 수정

## 🔁 변경 사항

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점

## ✅ 체크 리스트
- [ ] PR 템플릿에 맞추어 작성했어요.
- [ ] 변경 내용에 대한 테스트를 진행했어요.
- [ ] 프로그램이 정상적으로 동작해요.
- [ ] PR에 적절한 라벨을 선택했어요.
- [ ] 불필요한 코드는 삭제했어요.