### PR TITLE
🐛 fix: 빈 이미지 리스트 처리

### DIFF
--- a/src/main/java/com/example/echo/domain/capsule/controller/CapsuleController.java
+++ b/src/main/java/com/example/echo/domain/capsule/controller/CapsuleController.java
@@ -20,6 +20,7 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import reactor.core.publisher.Mono;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Slf4j
@@ -90,10 +91,16 @@ public class CapsuleController {
 
     @PostMapping(value = "/images", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @Operation(summary = "AWS S3 이미지 업로드 API", description = "S3와 DB 모두에 이미지를 생성합니다. 반환값은 DB에 생성된 이미지의 아이디입니다.")
-    public CustomResponse<List<Long>> uploadImage(@RequestPart("uploadFiles") List<MultipartFile> multipartFiles) {
+    public CustomResponse<List<Long>> uploadImage(@RequestPart(value = "uploadFiles", required = false) List<MultipartFile> multipartFiles) {
 
+        List<Long> imageIds = new ArrayList<>();
+
+        if (multipartFiles == null || multipartFiles.isEmpty()) {
+            return CustomResponse.onSuccess(imageIds);
+        }
+        // 유효한 파일이 있는 경우 uploadImages 실행
         List<Image> images = awsS3Service.uploadImages(multipartFiles);
-        List<Long> imageIds = images.stream()
+        imageIds = images.stream()
                 .map(Image::getId)
                 .toList();
         return CustomResponse.onSuccess(imageIds);

--- a/src/main/java/com/example/echo/domain/capsule/service/AwsS3Service.java
+++ b/src/main/java/com/example/echo/domain/capsule/service/AwsS3Service.java
@@ -43,7 +43,7 @@ public class AwsS3Service {
     public List<Image> uploadImages(List<MultipartFile> multipartFiles) {
 
         // S3 업로드 완료한 이미지들의 메타데이터를 담을 리스트
-        List<Image> imageIds = new ArrayList<>();
+        List<Image> images = new ArrayList<>();
 
         for (MultipartFile multipartFile : multipartFiles) {
 
@@ -68,10 +68,10 @@ public class AwsS3Service {
                     .imageUrl(s3FileName)
                     .build());
 
-            imageIds.add(image);
+            images.add(image);
         }
         // 전체 업로드 된 이미지 리스트 반환
-        return imageIds;
+        return images;
     }
 
     // S3와 DB에 이미지 삭제

--- a/src/main/java/com/example/echo/domain/capsule/service/command/CapsuleCommandService.java
+++ b/src/main/java/com/example/echo/domain/capsule/service/command/CapsuleCommandService.java
@@ -52,17 +52,20 @@ public class CapsuleCommandService {
     public Capsule mapCapsuleImage(Capsule capsule, List<Long> imageIds) {
 
         // 각 이미지 객체에 속하는 캡슐 set
-        List<Image> images = imageIds.stream()
-                .map(imageId -> {
-                    Image image = imageRepository.findById(imageId)
-                            .orElseThrow(() -> new ImageException(ImageErrorCode.NOT_FOUND));
-                    image.setCapsule(capsule);
-                    return image;
-                })
-                .toList();
+        // 이미지 리스트가 비어있는 경우, 받은 capsule 그대로 반환
+        if (!imageIds.isEmpty()) {
+            List<Image> images = imageIds.stream()
+                    .map(imageId -> {
+                        Image image = imageRepository.findById(imageId)
+                                .orElseThrow(() -> new ImageException(ImageErrorCode.NOT_FOUND));
+                        image.setCapsule(capsule);
+                        return image;
+                    })
+                    .toList();
 
-        // 속하는 캡슐에 이미지 리스트 set
-        capsule.setImageList(images);
+            // 속하는 캡슐에 이미지 리스트 set
+            capsule.setImageList(images);
+        }
         return capsule;
     }
 


### PR DESCRIPTION
# ☝️Issue Number

- #38 

##  📌 개요

- 이미지 업로드 API와 캡슐 생성 API에서, 각각 받아온 이미지 리스트가 empty일 경우 처리 코드 추가

## 🔁 변경 사항

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [ ] 변경 내용에 대한 테스트를 진행했어요.
- [ ] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.